### PR TITLE
Updated microsoft-graph plugin to 1.6.0 & gradle version upgrade to f…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,20 +40,20 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:27.0.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.volley:volley:1.1.0'
     // Include the SDK as a dependency
-    implementation 'com.microsoft.graph:microsoft-graph:1.2.0'
+    implementation 'com.microsoft.graph:microsoft-graph:1.6.0'
     implementation 'com.microsoft.graph:microsoft-graph-android-auth:0.1.0-SNAPSHOT'
     // Include GSON as a dependency
-    implementation 'com.google.code.gson:gson:2.6.2'
-    implementation 'commons-io:commons-io:2.0.1'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'commons-io:commons-io:2.4'
     // Test libraries
-    androidTestImplementation 'com.android.support:support-annotations:25.3.1'
-    androidTestImplementation 'com.android.support.test:runner:0.5'
-    androidTestImplementation 'com.android.support.test:rules:0.5'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:2.2.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-intents:2.2.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-web:2.2.2'
+    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-intents:3.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-web:3.0.2'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 16 16:17:00 EAT 2019
+#Mon Oct 21 21:49:53 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip


### PR DESCRIPTION
This repository was using an outdated Gradle distribution and on performing a Gradle sync on the repo the below issue was observed : ERROR: The specified Gradle distribution 'https://services.gradle.org/distributions/gradle-4.10.1-all.zip' does not appear to contain a Gradle distribution.

The Gradle distribution has been updated to 5.6.3 and the android build Gradle version has been updated to the latest 3.5.1 version, the remaining app level dependencies have been updated